### PR TITLE
using a case statement for commandline arguments

### DIFF
--- a/lrcm
+++ b/lrcm
@@ -200,28 +200,30 @@ function lrcm_log {
 
 
 # Commandline arguments
-if [[ "${1}" == "list" ]]
-then
-    lrcm_list
-elif [[ "${1}" == "show" ]]
-then
-    lrcm_show
-elif [[ "${1}" == "add" ]]
-then
-    arg2=${*:2}
-    no_cores
-    lrcm_add
-elif [[ "${1}" == "remove" ]]
-then
-    arg2=${*:2}
-    no_cores
-    lrcm_remove
-elif [[ "${1}" == "update" ]]
-then
-    lrcm_update
-elif [[ "${1}" == "log" ]]
-then
-    lrcm_log
-else
-    lrcm_usage
-fi
+case "$1" in
+    list)
+        lrcm_list
+        ;;
+    show)
+        lrcm_show
+        ;;
+    add)
+        arg2=${*:2}
+        no_cores
+        lrcm_add
+        ;;
+    remove)
+        arg2=${*:2}
+        no_cores
+        lrcm_remove
+        ;;
+    update)
+        lrcm_update
+        ;;
+    log)
+        lrcm_log
+        ;;
+    *)
+        lrcm_usage
+        ;;
+esac


### PR DESCRIPTION
Hello @cpinkus .

In this PR I've just replaced those nested if-elif-elif-elif with a case statement.

Would you mind if I submit other PRs trying to make this script more flexible?

By "more flexible" I mean "usable on many platforms, such as raspberry pi, windows (via Cygwin or msys2), with no need to make the user hardcode stuff in the script".

Thanks for sharing this!